### PR TITLE
upgrade test and build actions to v2

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.9"
 
     steps:
-      - uses: neuroinformatics-unit/actions/test@v1
+      - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -56,7 +56,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-    - uses: neuroinformatics-unit/actions/build_sdist_wheels@v1
+    - uses: neuroinformatics-unit/actions/build_sdist_wheels@v2
 
 
   upload_all:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Uploading v1.0.1 to PyPI [failed](https://github.com/brainglobe/brainglobe-space/actions/runs/9083044198/job/24961381417) due to the workflow using a build- and an upload action that were incompatible with each other.

**What does this PR do?**

Updates test-action and build-action to v2.

## References

None.

## How has this PR been tested?

Not directly. This is the same change that has fixed this [for other packages previously](https://github.com/neuroinformatics-unit/movement/pull/108)... we seem to have missed the fix here.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
